### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 An MCP (Model Context Protocol) Server that provides access to STAC (SpatioTemporal Asset Catalog) APIs for geospatial data discovery and access. Supports dual output modes (`text` and structured `json`) for all tools.
 
+<a href="https://glama.ai/mcp/servers/@BnJam/stac-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@BnJam/stac-mcp/badge" alt="STAC Server MCP server" />
+</a>
+
 > The coverage badge is updated automatically on pushes to `main` by the CI workflow.
 
 ## Overview
@@ -274,4 +278,3 @@ These documents provide guidance for:
 ## License
 
 Apache 2.0 - see [LICENSE](LICENSE) file for details.
-


### PR DESCRIPTION
This PR adds a badge for the [STAC MCP Server](https://glama.ai/mcp/servers/@BnJam/stac-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@BnJam/stac-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@BnJam/stac-mcp/badge" alt="STAC Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.