### PR TITLE
feature: add catalog_url parameter to get_root and get_conformance tools

### DIFF
--- a/stac_mcp/prompts/prompts.py
+++ b/stac_mcp/prompts/prompts.py
@@ -78,17 +78,29 @@ def register_prompts(app: Any) -> None:
         name="tool_get_root_prompt",
         description="Usage for get_root tool",
         meta={
-            "schema": {"type": "object", "properties": {}, "required": []},
-            "example": {},
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "catalog_url": {"type": "string"},
+                },
+                "required": [],
+            },
+            "example": {"catalog_url": "https://earth-search.aws.element84.com/v1"},
         },
     )
     def _prompt_get_root() -> PromptMessage:
-        schema = {"type": "object", "properties": {}, "required": []}
+        schema = {
+            "type": "object",
+            "properties": {
+                "catalog_url": {"type": "string"},
+            },
+            "required": [],
+        }
         payload = {
             "name": "get_root",
             "description": "Return the STAC root document for a catalog.",
             "parameters": schema,
-            "example": {},
+            "example": {"catalog_url": "https://earth-search.aws.element84.com/v1"},
         }
         human = (
             f"Tool: get_root\nDescription: {payload['description']}\n\n"
@@ -107,12 +119,24 @@ def register_prompts(app: Any) -> None:
         name="tool_get_conformance_prompt",
         description="Usage for get_conformance tool",
         meta={
-            "schema": {"type": "object", "properties": {}, "required": []},
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "catalog_url": {"type": "string"},
+                },
+                "required": [],
+            },
             "example": {},
         },
     )
     def _prompt_get_conformance() -> PromptMessage:
-        schema = {"type": "object", "properties": {}, "required": []}
+        schema = {
+            "type": "object",
+            "properties": {
+                "catalog_url": {"type": "string"},
+            },
+            "required": [],
+        }
         payload = {
             "name": "get_conformance",
             "description": "Return server conformance classes.",

--- a/stac_mcp/server.py
+++ b/stac_mcp/server.py
@@ -19,18 +19,22 @@ register_prompts(app)
 
 
 @app.tool
-async def get_root() -> list[dict[str, Any]]:
+async def get_root(
+    catalog_url: str | None = None,
+) -> list[dict[str, Any]]:
     """Return the STAC root document for a catalog."""
     return await execution.execute_tool(
-        "get_root", arguments={}, catalog_url=None, headers=None
+        "get_root", arguments={}, catalog_url=catalog_url, headers=None
     )
 
 
 @app.tool
-async def get_conformance() -> list[dict[str, Any]]:
+async def get_conformance(
+    catalog_url: str | None = None,
+) -> list[dict[str, Any]]:
     """Return server conformance classes."""
     return await execution.execute_tool(
-        "get_conformance", arguments={}, catalog_url=None, headers=None
+        "get_conformance", arguments={}, catalog_url=catalog_url, headers=None
     )
 
 


### PR DESCRIPTION
## Feature
Add `catalog_url` optional parameter to `get_root` and `get_conformance` tools,
bringing them in line with `search_collections`, `get_collection`, and other tools
that already support catalog switching.

## Before that
It was impossible to call `get_root` or `get_conformance` on a catalog other than
the server default without reconfiguring the server. This was inconsistent with
the rest of the toolset.

## Changes
- `stac_mcp/server.py`: add `catalog_url: str | None = None` to `get_root` and
  `get_conformance` signatures, passed through to `execute_tool`
- `stac_mcp/prompts.py`: update `tool_get_root_prompt` and
  `tool_get_conformance_prompt` schemas to document the new parameter

## Testing & Quality checks
- `ruff` -> ok 
- pytest -> Existing test suite passes (218 tests). Pre-existing failures in `test_fast_server`, `test_execution_fallbacks`, and prompt tests are unrelated to this change.