### PR TITLE
feat: add optional HTTP transport via env vars

### DIFF
--- a/stac_mcp/__main__.py
+++ b/stac_mcp/__main__.py
@@ -1,11 +1,26 @@
 """Entry point for running the STAC MCP server as ``python -m stac_mcp``."""
 
+import os
+
 from stac_mcp.server import app
 
 
 def main() -> None:
-    """Launch the STAC MCP server CLI."""
-    app.run()
+    """Launch the STAC MCP server CLI.
+
+    Defaults to stdio, matching every previously documented invocation.
+    Set STAC_MCP_TRANSPORT=http (or streamable-http/sse) to serve over HTTP
+    instead, configurable via STAC_MCP_HOST/STAC_MCP_PORT.
+    """
+    transport = os.environ.get("STAC_MCP_TRANSPORT", "stdio")
+    if transport == "stdio":
+        app.run()
+    else:
+        app.run(
+            transport=transport,
+            host=os.environ.get("STAC_MCP_HOST", "127.0.0.1"),
+            port=int(os.environ.get("STAC_MCP_PORT", "8000")),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cache_ttl_and_invalidation.py
+++ b/tests/test_cache_ttl_and_invalidation.py
@@ -6,10 +6,16 @@ import pytest
 from fastmcp import Client
 
 from stac_mcp.server import app
+from stac_mcp.tools import execution
 
 
 @pytest.mark.asyncio
 async def test_search_cache_hit():
+    # _get_cached_client keys on (catalog_url, headers); both are None/None
+    # here (the defaults), so a stale client from a prior test would be
+    # reused otherwise, along with its already-populated _search_cache.
+    execution._CLIENT_CACHE.clear()  # noqa: SLF001
+
     calls = {"n": 0}
 
     def search_fn(**_):
@@ -35,6 +41,12 @@ async def test_search_cache_hit():
 
 @pytest.mark.asyncio
 async def test_search_cache_ttl_expiry(monkeypatch):
+    # Same isolation reasoning as test_search_cache_hit above: without this,
+    # a client (and its _search_cache) left over from a prior test can be
+    # reused here, making the TTL-expiry assertion flaky depending on
+    # CPython id() reuse for the mocked client object between tests.
+    execution._CLIENT_CACHE.clear()  # noqa: SLF001
+
     calls = {"n": 0}
 
     def search_fn(**_):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from unittest.mock import patch
@@ -14,6 +15,34 @@ def test_main_entry_point():
     with patch("stac_mcp.server.app.run") as mock_run:
         main()
         mock_run.assert_called_once()
+
+
+def test_main_entry_point_stdio_is_default():
+    """Test that an unset STAC_MCP_TRANSPORT still calls app.run() bare."""
+    with patch.dict(os.environ, clear=False):
+        os.environ.pop("STAC_MCP_TRANSPORT", None)
+        with patch("stac_mcp.server.app.run") as mock_run:
+            main()
+            mock_run.assert_called_once_with()
+
+
+def test_main_entry_point_http_transport():
+    """Test that STAC_MCP_TRANSPORT=http forwards transport/host/port."""
+    env = {
+        "STAC_MCP_TRANSPORT": "http",
+        "STAC_MCP_HOST": "0.0.0.0",  # noqa: S104
+        "STAC_MCP_PORT": "9000",
+    }
+    with (
+        patch.dict(os.environ, env, clear=False),
+        patch("stac_mcp.server.app.run") as mock_run,
+    ):
+        main()
+        mock_run.assert_called_once_with(
+            transport="http",
+            host="0.0.0.0",  # noqa: S104
+            port=9000,
+        )
 
 
 def test_main_module_execution():


### PR DESCRIPTION
## Summary
- Adds an opt-in HTTP transport (`STAC_MCP_TRANSPORT=http`, configurable via `STAC_MCP_HOST`/`STAC_MCP_PORT`) alongside the existing stdio default.
- FastMCP already supports `transport="http"`; the entry point just never exposed it.
- Default remains `stdio` - every previously documented invocation (`docker run -i`, the `uvx` stdio MCP client config) is unaffected.

## Test plan
- [x] `ruff format` / `ruff check` clean
- [x] New tests: `test_main_entry_point_stdio_is_default`, `test_main_entry_point_http_transport`
- [x] Full suite green (239 passed, 3 skipped)