### PR TITLE
fix: Containerfile entrypoint never actually started the server

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,6 +30,10 @@ RUN uv sync
 RUN uv build
 RUN pip install dist/stac_mcp-*.whl
 
-# Set the entry point for the application
-ENTRYPOINT ["python", "-m", "stac_mcp.server"]
-CMD ["--help"]
+# Set the entry point for the application.
+# Use the console script declared in pyproject.toml ([project.scripts]),
+# not `python -m stac_mcp.server` - server.py only defines the FastMCP app
+# and registers tools, it has no `if __name__ == "__main__":` block, so
+# running it as a script just imports it and exits cleanly (exit 0) without
+# ever starting the server.
+ENTRYPOINT ["stac-mcp"]


### PR DESCRIPTION
## Summary
- `ENTRYPOINT ["python", "-m", "stac_mcp.server"]` runs `server.py` as a bare script. It only defines the `FastMCP` app and registers tools - there's no `if __name__ == "__main__":` block, so the process just imports the module and exits cleanly (code 0) without ever calling `.run()`.
- This means the published container image, run as documented (`docker run --rm -i ...`), never actually started the MCP server at all - stdio or HTTP, either way.
- `pyproject.toml` already declares the correct entry point (`stac-mcp = "stac_mcp.__main__:main"`); the Containerfile just never used it.

## How this was found
Deploying `2.3.0` (this platform's HTTP transport contribution) as an actual Kubernetes workload - the pod stayed "Running" but never became Ready, and the container kept exiting cleanly every few seconds with zero log output.

## Test plan
- [x] Built the image locally with the fix
- [x] `docker run` (HTTP transport via env vars) now starts FastMCP/uvicorn and logs startup normally
- [x] `curl -X POST /mcp` with a real `initialize` JSON-RPC request returns a valid MCP response (protocol version, capabilities, serverInfo)