### PR TITLE
fix: version-bump workflow silently skips squash-merged PRs

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -45,8 +45,15 @@ jobs:
           MERGE_MSG=$(git log -1 --pretty=format:"%s")
           echo "Merge message: $MERGE_MSG"
 
-          # Extract PR number from merge message
+          # Extract PR number from merge message. Supports both merge-commit
+          # style ("Merge pull request #123 from ...") and squash-merge style
+          # ("<PR title> (#123)", GitHub's default squash message) - without
+          # the second pattern, every squash-merged PR silently skips version
+          # bump/build/release with no error, which is easy to miss.
           PR_NUM=$(echo "$MERGE_MSG" | grep -oP "Merge pull request #\K\d+" || echo "")
+          if [ -z "$PR_NUM" ]; then
+            PR_NUM=$(echo "$MERGE_MSG" | grep -oP "\(#\K\d+(?=\)$)" || echo "")
+          fi
 
           if [ -z "$PR_NUM" ]; then
             echo "No PR number found in merge commit, skipping version bump"


### PR DESCRIPTION
## Summary
- The version-bump job's PR-number extraction (`grep -oP "Merge pull request #\K\d+"`) only matches GitHub's regular merge-commit message format.
- A squash merge's default message (`<title> (#123)`) never matches, so `PR_NUM` comes back empty and the job silently logs "No PR number found in merge commit, skipping version bump" - no failure, no warning surfaced anywhere obvious.
- `build`, `github-release`, and `pypi-publish` all gate on `version_changed`, so they silently skip too.

## Impact
Six PRs merged via squash in a row (5 dependency security bumps + a real Containerfile entrypoint fix) all landed on `main` but never triggered a version bump, tag, or published image/release - discovered only because a downstream deployment kept running the stale image and a real bug fix wasn't actually in it.

## Fix
Add a fallback regex matching the squash-merge message format, tried after the existing pattern. Either merge style now resolves the PR number correctly; everything downstream (label/branch-prefix detection, bump type, build, release) is unchanged.

## Test plan
- [x] Verified both patterns against real commit messages from this repo's history (a regular merge commit and several squash-merge commits) - correct match/no-match in all cases